### PR TITLE
Normalise ‘conversion’ tag

### DIFF
--- a/_posts/2015-10-29-aberdeen-1-percent.markdown
+++ b/_posts/2015-10-29-aberdeen-1-percent.markdown
@@ -10,6 +10,6 @@ categories:
 tags:
  - page views
  - satisfaction
- - conversions
+ - conversion
  - "2008"
 ---

--- a/_posts/2015-10-29-mozilla-2point2.markdown
+++ b/_posts/2015-10-29-mozilla-2point2.markdown
@@ -8,6 +8,6 @@ img:
 storySource: "http://blog.mozilla.com/metrics/category/website-optimization/"
 categories:
 tags: 
- - conversions
+ - conversion
  - "2010"
 ---

--- a/_posts/2015-10-29-shopzilla-12-percent.markdown
+++ b/_posts/2015-10-29-shopzilla-12-percent.markdown
@@ -8,7 +8,7 @@ img:
 storySource: "http://velocityconf.com/velocity2009/public/schedule/detail/7709"
 categories:
 tags: 
- - conversions
+ - conversion
  - page views
  - expense
  - "2009"

--- a/_posts/2015-11-03-doubleclick-redirect.markdown
+++ b/_posts/2015-11-03-doubleclick-redirect.markdown
@@ -8,7 +8,7 @@ storySource: "https://web.archive.org/web/20150423055300/http://doubleclickadver
 date:   2015-11-03 14:27:51
 categories:
 tags:
- - conversions
+ - conversion
  - engagement
  - "2011"
 ---

--- a/_posts/2015-11-04-intuit-conversions.markdown
+++ b/_posts/2015-11-04-intuit-conversions.markdown
@@ -7,6 +7,6 @@ img:
 storySource: "http://velocityconf.com/velocityny2013/public/schedule/detail/30146"
 date:   2015-11-04 13:27:51
 tags:
- - conversions
+ - conversion
  - "2013"
 ---

--- a/_posts/2015-11-04-obama-fourteen.markdown
+++ b/_posts/2015-11-04-obama-fourteen.markdown
@@ -7,6 +7,6 @@ img:
 storySource: "http://kylerush.net/blog/meet-the-obama-campaigns-250-million-fundraising-platform/"
 date:   2015-11-04 13:27:51
 tags:
- - conversions
+ - conversion
  - "2012"
 ---

--- a/_posts/2015-11-04-walmart-revenue.markdown
+++ b/_posts/2015-11-04-walmart-revenue.markdown
@@ -7,7 +7,7 @@ img:
 storySource: "http://www.slideshare.net/devonauerswald/walmart-pagespeedslide"
 date:   2015-11-04 13:27:51
 tags:
- - conversions
+ - conversion
  - revenue
  - "2013"
 ---

--- a/_posts/2015-11-13-auto-anything.markdown
+++ b/_posts/2015-11-13-auto-anything.markdown
@@ -4,7 +4,7 @@ title:  "AutoAnything reduced page load time by 50% and saw an 12-13% increase i
 storySource: "https://www.internetretailer.com/2010/08/19/web-accelerator-revs-conversion-and-sales-autoanything"
 date:   2015-11-13 12:45:51
 tags:
- - conversions
+ - conversion
  - revenue
  - "2010"
 ---

--- a/_posts/2015-11-13-etam-load-time.markdown
+++ b/_posts/2015-11-13-etam-load-time.markdown
@@ -4,7 +4,7 @@ title:  "Etam reduces it's average page load time from 1.2s to 500ms and increas
 storySource: "http://blog.quanta-computing.com/etam-earns-20-of-conversion-by-optimising-its-online-store/"
 date:   2015-11-13 08:27:51
 tags:
- - conversions
+ - conversion
  - engagement
  - page views
  - "2015"

--- a/_posts/2015-11-13-glasses-direct.markdown
+++ b/_posts/2015-11-13-glasses-direct.markdown
@@ -4,6 +4,6 @@ title:  "Glasses Direct found that for every second they added to the load time,
 storySource: "https://info.ensighten.com/rs/ensighten/images/just-one-second-delay-in-page-load-can-cause-7-percent-loss-in-customer-conversions.pdf"
 date:   2015-11-13 12:27:51
 tags:
- - conversions
+ - conversion
  - "2012"
 ---

--- a/_posts/2015-11-20-staples-load-time.markdown
+++ b/_posts/2015-11-20-staples-load-time.markdown
@@ -7,6 +7,6 @@ img:
  image: "staples-logo.png"
  alt: "Staples Logo"
 tags:
- - conversions
+ - conversion
  - "2014"
 ---


### PR DESCRIPTION
A lot of posts were split over two tags: ‘conversion’ and ‘conversions’.
This felt like it was possibly a typo, and made it much harder to see
all conversion-related case studies at once. I’ve folded them all into
the ‘conversion’ tag.