### PR TITLE
fix: update link to Driver Solutions Case Study

### DIFF
--- a/_posts/2018-11-13-driver-solutions-conversion.markdown
+++ b/_posts/2018-11-13-driver-solutions-conversion.markdown
@@ -1,11 +1,11 @@
 ---
 layout: post
-title:  "Web studio Sparkbox more than doubled Driver Solutions’ conversion rate for organic traffic, moving it from 2.69% to 5.57% after deploying performance updates and AMP pages."
-storySource: "https://jobs.zalando.com/tech/blog/loading-time-matters/index.html"
-date:   2018-11-13 06:50:51
+title: "Web studio Sparkbox more than doubled Driver Solutions’ conversion rate for organic traffic, moving it from 2.69% to 5.57% after deploying performance updates and AMP pages."
+storySource: "https://seesparkbox.com/foundry/driver_solutions_website_load_faster_performance_optimization"
+date: 2018-11-13 06:50:51
 tags:
- - conversion
- - search
- - seo
- - "2018"
+  - conversion
+  - search
+  - seo
+  - "2018"
 ---


### PR DESCRIPTION
I work at Sparkbox and we noticed that the link for this case study was going to the wrong URL.